### PR TITLE
Align with curio

### DIFF
--- a/pytest_curio/plugin.py
+++ b/pytest_curio/plugin.py
@@ -44,6 +44,6 @@ def pytest_runtest_setup(item):
 @pytest.fixture(scope="session")
 def kernel(request):
     """Create an instance of the default kernel for each test case."""
-    kernel = Kernel()
+    kernel = curio.Kernel()
     request.addfinalizer(lambda: kernel.run(shutdown=True))
     return kernel


### PR DESCRIPTION
Hello, thanks for your work ! I've learned few things with pytest cause of you :)

Here, I purpose you few change:
- align kernel call to last released curio version (no add_task), use curio.meta to test coroutine
- add a kernel finalizer on fixture with a session scope
- raise root cause exception on error (rewrote of https://github.com/johnnoone/pytest-curio/pull/2/files)

Tested with success on pynng (curio integration is a work in progress)

