### PR TITLE
Make versioneer compatible with Python 3.12.

### DIFF
--- a/versioneer.py
+++ b/versioneer.py
@@ -396,9 +396,9 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+        parser.read_file(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):


### PR DESCRIPTION
SafeConfigParser was [deprecated in Python
3.2](https://docs.python.org/3/whatsnew/3.2.html#configparser) and [removed in Python
3.12](https://docs.python.org/3/whatsnew/3.12.html#configparser). The readfp method was removed in favor of read_file as well.
I was able to test that this still worked with Python 3.7, but that is the oldest I could test on.